### PR TITLE
re-add nightlies and support fortress

### DIFF
--- a/ign_rocker/ignition.py
+++ b/ign_rocker/ignition.py
@@ -11,7 +11,7 @@ class Ignition(RockerExtension):
 
     @staticmethod
     def get_releases():
-        return {'citadel', 'dome', 'edifice'}
+        return {'citadel', 'dome', 'edifice', 'fortress'}
 
     @staticmethod
     def get_OSs():

--- a/ign_rocker/templates/ignition_snippet.Dockerfile.em
+++ b/ign_rocker/templates/ignition_snippet.Dockerfile.em
@@ -22,7 +22,9 @@ RUN apt-get -qq update && apt-get -y --no-install-recommends install \
   && rm -rf /var/lib/apt/lists/*
 
 # set up repositories for Ignition
+# (add nightlies in case users want the newest Ignition version)
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+  && sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list' \
   && wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 
 # install colcon, vcstool and psutil (psutil is for sdformat memory leak tests)


### PR DESCRIPTION
https://github.com/adlarkin/ign-rocker/commit/3693b2c11f1745257634d48f6b8be9ffab7f8145 removed the nightlies since the Edifice release no longer requires them. However, I think it's best to leave the nightlies in so that users can always use the newest Ignition version if they wish. I have also added support for running `fortress` as the ignition version.